### PR TITLE
fix(ci): replace compromised trivy-action with direct CLI install

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -187,14 +187,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install Trivy CLI
+        # Avoids aquasecurity/trivy-action which had a supply chain compromise in March 2026
+        # (75 of 76 version tags force-pushed to serve malicious payloads)
+        # Direct binary download from GitHub Releases is unaffected.
+        env:
+          TRIVY_VERSION: '0.62.0'
+        run: |
+          curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o trivy.tar.gz
+          tar -xzf trivy.tar.gz trivy
+          sudo mv trivy /usr/local/bin/trivy
+          rm trivy.tar.gz
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+        run: |
+          trivy fs --severity CRITICAL,HIGH --format sarif --output trivy-results.sarif .
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Security Fix — URGENT

`aquasecurity/trivy-action` had 75 of 76 version tags force-pushed in March 2026 to serve malicious payloads that exfiltrate CI/CD secrets. The `@0.29.0` tag used in this repo was among those compromised.

## What changed

Replaced the `uses: aquasecurity/trivy-action@0.29.0` step with a direct binary download from the official Trivy GitHub Releases endpoint, pinned to `v0.62.0`. The binary download path is unaffected by the Action tag compromise.

The SARIF upload step (`github/codeql-action/upload-sarif@v4`) is maintained by GitHub and is not affected.

## References
- CrowdStrike: *From Scanner to Stealer: Inside the trivy-action Supply Chain Compromise*
- The Hacker News: *Trivy Security Scanner GitHub Actions Breached*
- Snyk: *Trivy GitHub Actions Supply Chain Compromise*

## Test plan
- [ ] `security-scan` job passes in CI
- [ ] SARIF results appear in GitHub Security tab